### PR TITLE
Making code example more compilable

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -94,8 +94,8 @@ for building a database: just add data.</p>
 point it at some data.</p>
 
 <figure class="highlight"><pre><code class="language-java" data-lang="java"><span class="kd">public</span> <span class="kd">static</span> <span class="kd">class</span> <span class="nc">HrSchema</span> <span class="o">{</span>
-  <span class="kd">public</span> <span class="kd">final</span> <span class="nc">Employee</span><span class="o">[]</span> <span class="n">emps</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span>
-  <span class="kd">public</span> <span class="kd">final</span> <span class="nc">Department</span><span class="o">[]</span> <span class="n">depts</span> <span class="o">=</span> <span class="mi">0</span><span class="o">;</span>
+  <span class="kd">public</span> <span class="kd">final</span> <span class="nc">Employee</span><span class="o">[]</span> <span class="n">emps</span> <span class="o">=</span> <span class="kd">new</span> <span class="nc">Employee</span><span class="o">[</span><span class="mi">0</span><span class="o">];</span>
+  <span class="kd">public</span> <span class="kd">final</span> <span class="nc">Department</span><span class="o">[]</span> <span class="n">depts</span> <span class="o">=</span> <span class="kd">new</span> <span class="nc">Department</span><span class="o">[</span><span class="mi">0</span><span class="o">];</span>
 <span class="o">}</span>
 <span class="nc">Class</span><span class="o">.</span><span class="na">forName</span><span class="o">(</span><span class="s">"org.apache.calcite.jdbc.Driver"</span><span class="o">);</span>
 <span class="nc">Properties</span> <span class="n">info</span> <span class="o">=</span> <span class="k">new</span> <span class="nc">Properties</span><span class="o">();</span>


### PR DESCRIPTION
Line of code:
`public final Employee[] emps = 0;`
is not valid from java side. It was changed to 
`public final Employee[] emps = new Employee[0];`
This line can be compiled by Java compiler